### PR TITLE
missing DTYP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 db
 dbd
 iocBoot/iocCaenelsFastPS/envPaths
+O.*/

--- a/CaenelsFastPSApp/Db/fastps.db
+++ b/CaenelsFastPSApp/Db/fastps.db
@@ -256,6 +256,7 @@ record (stringin, "$(P)$(R)Version")
 record(mbbiDirect, "$(P)$(R)_EnableInit")
 {
     field(DESC, "Initialization for Enable")
+    field(DTYP, "stream")
     field(PINI, "YES")
     field(INP,  "@fastps.proto getStatusLSB L0")
     field(FLNK, "$(P)$(R)_EnableInitCalc")


### PR DESCRIPTION
Cloning and running this IOC for the first time gives me:

```
Error: caenels:fastps:_EnableInit.INP: can't initialize link type 0 with "@fastps.proto getStatusLSB L0" (type 12)
```

Fix this by adding missing DTYP, also have git ignore object code directories.

This is with EPICS 7.0.2, asyn R4-34, and stream R2-7-7b

Otherwise.  So far so good...